### PR TITLE
remove identation from extern 'C' block

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,7 +34,7 @@ BraceWrapping:
   AfterObjCDeclaration: true
   AfterStruct:     false
   AfterUnion:      false
-  AfterExternBlock: true
+  AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
   IndentBraces:    false


### PR DESCRIPTION
Changed BraceWrapping:AfterExternBlock to false, removing unwanted indentation in .h's
The style checker will need to be rerun on .h files.