### PR TITLE
Fix workload test build

### DIFF
--- a/workload/tests/CMakeLists.txt
+++ b/workload/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.13)
 set(TARGET_NAME "workload_test")
 project(${TARGET_NAME} VERSION 0.0.1 LANGUAGES C CXX)
 
-file(COPY ../tests/resources/ DESTINATION ${PROJECT_BINARY_DIR}/workload/tests/resources/)
+file(COPY ./resources/ DESTINATION ${PROJECT_BINARY_DIR}/resources/)
 
 # Include generated *.pb.h files
 include_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/workload/tests/check_client.cc
+++ b/workload/tests/check_client.cc
@@ -9,9 +9,9 @@
 
 #include "../../svid/x509svid/src/svid.h"
 #include "../src/client.h"
-#include "workload.grpc.pb.h"
-#include "workload.pb.h"
-#include "workload_mock.grpc.pb.h"
+#include "../workload.grpc.pb.h"
+#include "../workload.pb.h"
+#include "../workload_mock.grpc.pb.h"
 #include <check.h>
 #include <gmock/gmock.h>
 #include <grpc/grpc.h>


### PR DESCRIPTION
after removing .proto to cpp file generation in workload/tests/CMakefiles.txt, we need to redirect them to the ones generated by workload/CMakefiles.txt
Likewise, test resources were being copied to the wrong directory.

Bug wasn't detected since the files from previous builds remained. Always remember to clean before cmake.