### PR TITLE
Clearing some warnings on Documentation; Fixing a broken link

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,6 @@
 # Building
 
-## Docker Building(recommended)
+## Docker Building (recommended)
 
 ### Docker Build Dependencies
 
@@ -119,7 +119,7 @@ make install
 
 ## Code Coverage Support
 
-This project generates Code Coverage Reports using either using `gcov` and `lcov`.
+This project generates Code Coverage Reports using either `gcov` and `lcov`.
 If you want to generate cover reports, you should run the following command after `make test`:
 
 ```bash

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,16 +2,15 @@
 
 ## Docker Building(recommended)
 
-### Dependencies
+### Docker Build Dependencies
 
 * Docker
 
-###  Build Docker Image
-
+### Build Docker Image
 
 You can build the docker image from source with the following command line:
 
-```
+```bash
 git clone git@github.com:HewlettPackard/c-spiffe.git
 cd c-spiffe
 docker build -f docker/grpc.Dockerfile --build-arg GPRC_VERSION=1.34.0 --build-arg NUM_JOBS=8 --tag grpc-build:1.34.0 .
@@ -21,43 +20,47 @@ docker build -f docker/grpc.Dockerfile --build-arg GPRC_VERSION=1.34.0 --build-a
 
 Or you can use a pre-built image:
 
-````
+````bash
 docker pull willallves/grpc-build:1.34.0
 ````
 
 #### Run Docker Container
 
-##### Setting volume path: <code>/mnt/<code>
+##### Setting volume path: `/mnt/`
 
-```
+```bash
 docker run -it --rm --network host -v $(pwd):/mnt grpc-build:1.34.0
 ```
 
-##### For Windows 
+##### For Windows
 
-```
+```bash
 docker run -it --rm --network host -v <ABSOLUTE_PATH_TO_CSPIFFE>:/mnt grpc-build:1.34.0
 ```
+
 In the path `ABSOLUTE_PATH_TO_CSPIFFE`, start with `//` and don't use `:`. For example, if your code is in `C:\repositories\c-spiffe`, then you'll run:
 
-```
+```bash
 docker run -it --rm --network host -v //c/repositories/c-spiffe:/mnt grpc-build:1.34.0
 ```
 
-#### Building
+#### Docker Building
+
 Build the c-spiffe project:
-```
+
+```bash
 cd /mnt
 mkdir build && cd build
 cmake ..
 make
 make test
 ```
+
 After running `make test`, you will find the test files in the `Testing` folder.
 
 ## Local building
 
-### Dependencies
+### Local Build Dependencies
 
 * Gcc
 * CMake
@@ -82,12 +85,13 @@ In order to create a pure C lib, supporting gRPC, which is a C++ lib, it is nece
 
 Currently, we are using `GRPC_VERSION=1.34.0`
 
-```
+```bash
 cd /tmp && git clone --recurse-submodules -b v${GRPC_VERSION} https://github.com/grpc/grpc
 ```
-*  Build grpc
 
-```
+* Build grpc
+
+```bash
 cd /tmp/grpc/cmake/build && cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=ON ../..
 
 # Skipping benchmark tests
@@ -95,11 +99,12 @@ RUN sed -i '7,13d' /tmp/grpc/third_party/benchmark/test/cxx03_test.cc
 
 RUN cd /tmp/grpc/cmake/build && make -j${NUM_JOBS} && make install
 ```
+
 ### Compile C-Spiffe library
 
 Once you meet all the requirements, building is straightforward with `CMake`
 
-```
+```bash
 mkdir build && cd build
 cmake ..
 make
@@ -108,21 +113,19 @@ make test
 
 ### Installing
 
-```
+```bash
 make install
 ```
-
 
 ## Code Coverage Support
 
 This project generates Code Coverage Reports using either using `gcov` and `lcov`.
 If you want to generate cover reports, you should run the following command after `make test`:
 
-```
+```bash
 make gcov
 make lcov
 ```
 
 The coverage reports will be written to the `Coverage` folder. In the case of `lcov`, you
 can see it opening the `index.html` file on the folder above in your browser.
-

--- a/CI.md
+++ b/CI.md
@@ -12,4 +12,3 @@ Our Continuous Integration pipeline currently runs on Github Actions and is exec
 * Verify if current coverage is acceptable for lines and functions
   
 If any of the above steps fail, the build fails. Any Pull Request with failing builds should be rejected.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 ## Contributing
 
 In order to contribute to the project, the following steps should be followed:
+
 1. Fork the main repository
 2. Create your feature branch
 3. Commit your local changes in the feature branch
@@ -13,7 +14,7 @@ Pull request are going to be reviewed by maintainers, some change may be request
 
 ## Development setup
 
-For development purposes, we recommend to build an run inside a docker container. Refer to  [BUILDING.md](BUILDING.MD) for more information.
+For development purposes, we recommend to build an run inside a docker container. Refer to  [BUILDING.md](BUILDING.md) for more information.
 
 ## Conventions
 
@@ -21,4 +22,4 @@ This project follows the [GNU Coding Standard](https://www.gnu.org/prep/standard
 
 ## Continuous Integration
 
-This project uses Github Actions as Continuous Integration tool. Refer to [CI.md](CI.MD) for mor information.
+This project uses Github Actions as Continuous Integration tool. Refer to [CI.md](CI.md) for mor information.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Pull request are going to be reviewed by maintainers, some change may be request
 
 ## Development setup
 
-For development purposes, we recommend to build an run inside a docker container. Refer to  [BUILDING.md](BUILDING.md) for more information.
+For development purposes, we recommend to build and run inside a docker container. Refer to  [BUILDING.md](BUILDING.md) for more information.
 
 ## Conventions
 
@@ -22,4 +22,4 @@ This project follows the [GNU Coding Standard](https://www.gnu.org/prep/standard
 
 ## Continuous Integration
 
-This project uses Github Actions as Continuous Integration tool. Refer to [CI.md](CI.md) for mor information.
+This project uses Github Actions as Continuous Integration tool. Refer to [CI.md](CI.md) for more information.

--- a/README.md
+++ b/README.md
@@ -8,33 +8,29 @@ C extension for Spiffe platform.
 
 ## Introduction
 
-[SPIFFE](https://spiffe.io/) stands for Security Identity Framework for Everyone and is a set for securely identifying system in dynamic and heterogeneous environment. Please refer to https://spiffe.io/docs/latest/spiffe-about/overview/ for more information.  
+[SPIFFE](https://spiffe.io/) stands for Security Identity Framework for Everyone and is a set for securely identifying system in dynamic and heterogeneous environment. Please refer to [SPIFFE Documentation](https://spiffe.io/docs/latest/spiffe-about/overview/) for more information.  
 C-spiffe is an extension for Spiffe that allows any [workload](https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/#workload) written C, C++ or  any language that supports loading a .so library, access [Workload API](https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/#spiffe-workload-api) and establish a mTLS connection with other workloads.  
 The image above shows an example, where a C/C++ Workload imports the c-spiffe library in order to fetch a [SVID](https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/#spiffe-verifiable-identity-document-svid) and use it to establish a mTLS connection with another Workload, which can be implemented in another language, provided it follows the SPIFFE standard.
-
 
 ![Alt text](img/cspiffe_example.png "C-spiffe usage example")
 
 ### Motivation
 
-
 Even though there is an official [c-spiffe](https://github.com/spiffe/c-spiffe) library, we started this one from scratch. We wanted a C implementation (not C++) for better compatibility. We also based most of the design decisions on [go-spiffe](https://github.com/spiffe/c-spiffe), which is the offical supported extension by the Spiffe Community.
 
-
 ## Examples
- 
-Refer to [Examples](workload/src/EXAMPLE.md) for more information.
 
+Refer to [Examples](workload/src/EXAMPLE.md) for more information.
 
 ## Project structure
 
-
 ### Folders
+
 The project folder structure is described as follows:
 
 * **bundle** Source code for bundle module
 * **cmake** Configuration for cmake build
-* **docker** Configuration files for container used to build 
+* **docker** Configuration files for container used to build this lib
 * **img** Images files for documentations
 * **infra** Container orchestration for tests environment
 * **integration_test** Source code for automated test
@@ -45,7 +41,6 @@ The project folder structure is described as follows:
 * **svid** Source code for SVID module
 * **utils** Source code for utility functions
 * **workload** Source code for workload
-
 
 ### Remarkable files
 
@@ -62,7 +57,8 @@ The project folder structure is described as follows:
 ### Installing
 
 #### Install from source
-Reffer to [BUILDING.md](BUILDING.md) 
+
+Reffer to [BUILDING.md](BUILDING.md)
 
 #### Install on system
 
@@ -83,4 +79,5 @@ Refer to [Examples](workload/src/EXAMPLE.md) for more information.
 * Willian Alves
 
 ## Contributing
+
 Refer to [Contributing](workload/src/CONTRIBUTING.md) for more information.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The image above shows an example, where a C/C++ Workload imports the c-spiffe li
 
 ### Motivation
 
-Even though there is an official [c-spiffe](https://github.com/spiffe/c-spiffe) library, we started this one from scratch. We wanted a C implementation (not C++) for better compatibility. We also based most of the design decisions on [go-spiffe](https://github.com/spiffe/c-spiffe), which is the offical supported extension by the Spiffe Community.
+Even though there is an official [c-spiffe](https://github.com/spiffe/c-spiffe) library, we started this one from scratch. We wanted a C implementation (not C++) for better compatibility. We also based most of the design decisions on [go-spiffe](https://github.com/spiffe/go-spiffe), which is the offical supported extension by the Spiffe Community.
 
 ## Examples
 
@@ -80,4 +80,4 @@ Refer to [Examples](workload/src/EXAMPLE.md) for more information.
 
 ## Contributing
 
-Refer to [Contributing](workload/src/CONTRIBUTING.md) for more information.
+Refer to [Contributing](CONTRIBUTING.md) for more information.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ The image above shows an example, where a C/C++ Workload imports the c-spiffe li
 
 Even though there is an official [c-spiffe](https://github.com/spiffe/c-spiffe) library, we started this one from scratch. We wanted a C implementation (not C++) for better compatibility. We also based most of the design decisions on [go-spiffe](https://github.com/spiffe/go-spiffe), which is the offical supported extension by the Spiffe Community.
 
-## Examples
-
-Refer to [Examples](workload/src/EXAMPLE.md) for more information.
-
 ## Project structure
 
 ### Folders


### PR DESCRIPTION
Clearing documentations warnings (e.g Multiple blanks lines, no language description on code blocks, etc)
Fixing a broken link to BUILDING.md (from Contributing page)